### PR TITLE
Clarify session authentication method prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Key commands inside the shell:
 | `clear`                               | Clear the terminal and reprint the banner.                                  |
 | `exit`                                | Gracefully shut down ServerCommander.                                       |
 
+> **Note:** When prompted for the authentication method during `session add`, enter `password` or `private_key`. Passwords are never stored—if you choose `password` you will be asked for it when connecting.
+
 ### Requirements
 
 - Go 1.20+ for building (the module targets Go 1.23).

--- a/src/cmd/session.go
+++ b/src/cmd/session.go
@@ -191,13 +191,19 @@ func promptSessionDetails(alias string, existing config.Session, exists bool) (c
 
 	authMethod := config.AuthMethod(authDefault)
 	if protocol != config.ProtocolFTP {
-		authInput, err := utils.Prompt("Authentication (password/private_key)", authDefault)
-		if err != nil {
-			return config.Session{}, err
-		}
-		authMethod = config.AuthMethod(strings.ToLower(authInput))
-		if authMethod != config.AuthPassword && authMethod != config.AuthPrivateKey {
-			return config.Session{}, fmt.Errorf("unsupported auth method '%s'", authMethod)
+		authInput := authDefault
+		for {
+			authInput, err = utils.Prompt("Authentication method (password/private_key)", authInput)
+			if err != nil {
+				return config.Session{}, err
+			}
+
+			authMethod = config.AuthMethod(strings.ToLower(authInput))
+			if authMethod == config.AuthPassword || authMethod == config.AuthPrivateKey {
+				break
+			}
+
+			fmt.Printf("%sUnsupported value. Enter 'password' to supply the password when connecting or 'private_key' to use a key file.%s\n", utils.Yellow, utils.Reset)
 		}
 	} else {
 		authMethod = config.AuthPassword


### PR DESCRIPTION
## Summary
- re-prompt for the authentication method during `session add` until a supported value is provided
- explain in the README that the prompt expects `password` or `private_key` and that passwords are requested at connect time

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f7b38e2e54832ca30a942c9126680f