### PR TITLE
Create desktop console window with context menu

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module servercommander
 
 go 1.23.5
+
+require fyne.io/fyne/v2 v2.4.5

--- a/src/cmd/clear.go
+++ b/src/cmd/clear.go
@@ -10,6 +10,11 @@ import (
 )
 
 func clearCommand(args []string) error {
+	if ui.ClearConsole() {
+		ui.ApplicationBanner()
+		return nil
+	}
+
 	clearCmd, err := getClearCommand()
 	if err != nil {
 		return fmt.Errorf("failed to determine clear command: %w", err)

--- a/src/main.go
+++ b/src/main.go
@@ -1,35 +1,14 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	"os"
-	"strings"
+	"log"
 
 	"servercommander/src/cmd"
 	"servercommander/src/ui"
-	"servercommander/src/utils"
 )
 
 func main() {
-	ui.ApplicationBanner()
-	reader := bufio.NewReader(os.Stdin)
-
-	for {
-		fmt.Print(utils.Yellow, "\n>> ", utils.Reset)
-		input, err := reader.ReadString('\n')
-		if err != nil {
-			fmt.Println(utils.Red, "Failed to read input:", err, utils.Reset)
-			continue
-		}
-
-		command := strings.TrimSpace(input)
-		if command == "" {
-			continue
-		}
-
-		if err := cmd.Execute(command); err != nil {
-			fmt.Println(utils.Red, err, utils.Reset)
-		}
+	if err := ui.RunStandaloneConsole(cmd.Execute); err != nil {
+		log.Fatal(err)
 	}
 }

--- a/src/ui/desktop_console.go
+++ b/src/ui/desktop_console.go
@@ -1,0 +1,412 @@
+package ui
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/canvas"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+
+	"servercommander/src/utils"
+)
+
+type commandExecutor func(string) error
+
+var (
+	consoleInstance *DesktopConsole
+	consoleMu       sync.RWMutex
+)
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
+
+const (
+	portfolioLink = "https://uplytech.com/portfolio"
+	websiteLink   = "https://uplytech.com"
+)
+
+// DesktopConsole encapsulates the GUI console experience, piping stdout and
+// stderr into a dedicated window that accepts command execution requests.
+type DesktopConsole struct {
+	executor commandExecutor
+
+	app    fyne.App
+	window fyne.Window
+
+	output   *widget.Label
+	scroller *container.Scroll
+	input    *widget.Entry
+
+	stdoutPipe *os.File
+	stderrPipe *os.File
+	origStdout *os.File
+	origStderr *os.File
+
+	logMu      sync.Mutex
+	logBuilder strings.Builder
+
+	cleanupOnce sync.Once
+}
+
+// RunStandaloneConsole launches the GUI console and blocks until it closes.
+func RunStandaloneConsole(executor func(string) error) error {
+	console := &DesktopConsole{executor: executor}
+
+	application := app.New()
+	console.app = application
+
+	if err := console.redirectStandardStreams(); err != nil {
+		return err
+	}
+
+	consoleMu.Lock()
+	consoleInstance = console
+	consoleMu.Unlock()
+
+	defer func() {
+		console.cleanup()
+		consoleMu.Lock()
+		consoleInstance = nil
+		consoleMu.Unlock()
+	}()
+
+	return console.run()
+}
+
+// ClearConsole removes the accumulated log content from the GUI window.
+func ClearConsole() bool {
+	consoleMu.RLock()
+	console := consoleInstance
+	consoleMu.RUnlock()
+	if console == nil {
+		return false
+	}
+
+	console.clear()
+	return true
+}
+
+func (c *DesktopConsole) run() error {
+	c.window = c.app.NewWindow("ServerCommander")
+	c.window.SetMaster()
+	c.window.SetFixedSize(true)
+	c.window.Resize(fyne.NewSize(960, 600))
+	c.window.CenterOnScreen()
+
+	c.window.SetCloseIntercept(func() {
+		c.cleanup()
+		c.window.Close()
+	})
+
+	c.buildUI()
+
+	c.window.Show()
+	ApplicationBanner()
+	c.app.Run()
+	return nil
+}
+
+func (c *DesktopConsole) buildUI() {
+	c.output = widget.NewLabel("")
+	c.output.TextStyle = fyne.TextStyle{Monospace: true}
+	c.output.Wrapping = fyne.TextWrapWord
+	c.scroller = container.NewVScroll(c.output)
+	c.scroller.SetMinSize(fyne.NewSize(0, 400))
+
+	c.input = widget.NewEntry()
+	c.input.SetPlaceHolder("Befehl eingeben und Enter drücken…")
+	c.input.OnSubmitted = func(text string) {
+		c.submitCommand(text)
+	}
+
+	runButton := widget.NewButton("Ausführen", func() {
+		c.submitCommand(c.input.Text)
+	})
+	runButton.Importance = widget.HighImportance
+
+	clearButton := widget.NewButton("Leeren", func() {
+		c.clear()
+		ApplicationBanner()
+	})
+
+	actions := container.NewHBox(clearButton, layout.NewSpacer(), runButton)
+	footer := container.NewBorder(nil, nil, nil, actions, c.input)
+
+	header := container.NewHBox(newLogoWidget(c), layout.NewSpacer())
+
+	c.window.SetContent(container.NewBorder(header, footer, nil, nil, c.scroller))
+}
+
+func (c *DesktopConsole) submitCommand(command string) {
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		return
+	}
+
+	c.input.SetText("")
+	c.appendLog(">> " + trimmed + "\n")
+
+	go c.executeCommand(trimmed)
+}
+
+func (c *DesktopConsole) executeCommand(command string) {
+	if c.executor == nil {
+		return
+	}
+
+	if err := c.executor(command); err != nil {
+		fmt.Println(utils.Red, err.Error(), utils.Reset)
+	}
+}
+
+func (c *DesktopConsole) redirectStandardStreams() error {
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("failed to redirect stdout: %w", err)
+	}
+
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		stdoutReader.Close()
+		stdoutWriter.Close()
+		return fmt.Errorf("failed to redirect stderr: %w", err)
+	}
+
+	c.stdoutPipe = stdoutWriter
+	c.stderrPipe = stderrWriter
+	c.origStdout = os.Stdout
+	c.origStderr = os.Stderr
+
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+
+	go c.readPipe(stdoutReader, c.origStdout)
+	go c.readPipe(stderrReader, c.origStderr)
+
+	return nil
+}
+
+func (c *DesktopConsole) readPipe(pipe *os.File, mirror *os.File) {
+	reader := bufio.NewReader(pipe)
+	buffer := make([]byte, 1024)
+	var pending strings.Builder
+
+	for {
+		n, err := reader.Read(buffer)
+		if n > 0 {
+			chunk := buffer[:n]
+			if mirror != nil {
+				_, _ = mirror.Write(chunk)
+			}
+
+			pending.Write(chunk)
+			emit, remainder := splitANSISequences(pending.String())
+			if emit != "" {
+				c.appendLog(emit)
+			}
+
+			pending.Reset()
+			if remainder != "" {
+				pending.WriteString(remainder)
+			}
+		}
+
+		if err != nil {
+			if pending.Len() > 0 {
+				c.appendLog(pending.String())
+			}
+			return
+		}
+	}
+}
+
+func (c *DesktopConsole) appendLog(text string) {
+	cleaned := sanitizeText(text)
+	if cleaned == "" {
+		return
+	}
+
+	c.logMu.Lock()
+	c.logBuilder.WriteString(cleaned)
+	logSnapshot := c.logBuilder.String()
+	c.logMu.Unlock()
+
+	if c.app == nil {
+		return
+	}
+
+	c.app.QueueUpdate(func() {
+		if c.output != nil {
+			c.output.SetText(logSnapshot)
+		}
+		if c.scroller != nil {
+			c.scroller.ScrollToBottom()
+		}
+	})
+}
+
+func (c *DesktopConsole) clear() {
+	c.logMu.Lock()
+	c.logBuilder.Reset()
+	c.logMu.Unlock()
+
+	if c.app == nil {
+		return
+	}
+
+	c.app.QueueUpdate(func() {
+		if c.output != nil {
+			c.output.SetText("")
+		}
+		if c.scroller != nil {
+			c.scroller.ScrollToTop()
+		}
+	})
+}
+
+func (c *DesktopConsole) cleanup() {
+	c.cleanupOnce.Do(func() {
+		if c.stdoutPipe != nil {
+			c.stdoutPipe.Close()
+		}
+		if c.stderrPipe != nil {
+			c.stderrPipe.Close()
+		}
+		if c.origStdout != nil {
+			os.Stdout = c.origStdout
+		}
+		if c.origStderr != nil {
+			os.Stderr = c.origStderr
+		}
+	})
+}
+
+func sanitizeText(text string) string {
+	if text == "" {
+		return ""
+	}
+
+	cleaned := ansiPattern.ReplaceAllString(text, "")
+	cleaned = strings.ReplaceAll(cleaned, "\r\n", "\n")
+	cleaned = strings.ReplaceAll(cleaned, "\r", "\n")
+	return cleaned
+}
+
+func splitANSISequences(input string) (string, string) {
+	last := strings.LastIndexByte(input, 0x1b)
+	if last == -1 {
+		return input, ""
+	}
+
+	fragment := input[last:]
+	if fragment == "" {
+		return input, ""
+	}
+
+	if ansiSequenceComplete(fragment) {
+		return input, ""
+	}
+
+	return input[:last], fragment
+}
+
+func ansiSequenceComplete(fragment string) bool {
+	if len(fragment) < 2 {
+		return false
+	}
+
+	if fragment[0] != 0x1b {
+		return true
+	}
+
+	if fragment[1] != '[' {
+		return true
+	}
+
+	for i := 2; i < len(fragment); i++ {
+		b := fragment[i]
+		if (b >= '0' && b <= '9') || b == ';' {
+			continue
+		}
+		if b >= '@' && b <= '~' {
+			return true
+		}
+		return false
+	}
+
+	return false
+}
+
+type logoWidget struct {
+	widget.BaseWidget
+
+	label  *canvas.Text
+	parent *DesktopConsole
+}
+
+func newLogoWidget(console *DesktopConsole) *logoWidget {
+	widget := &logoWidget{parent: console}
+	widget.ExtendBaseWidget(widget)
+	return widget
+}
+
+func (l *logoWidget) CreateRenderer() fyne.WidgetRenderer {
+	l.label = canvas.NewText("ServerCommander", theme.PrimaryColor())
+	l.label.TextStyle = fyne.TextStyle{Bold: true}
+	l.label.Alignment = fyne.TextAlignCenter
+
+	content := container.NewCenter(l.label)
+	return widget.NewSimpleRenderer(content)
+}
+
+func (l *logoWidget) MinSize() fyne.Size {
+	if l.label == nil {
+		return fyne.NewSize(140, 48)
+	}
+
+	min := l.label.MinSize()
+	return fyne.NewSize(min.Width+32, min.Height+16)
+}
+
+func (l *logoWidget) Tapped(_ *fyne.PointEvent) {}
+
+func (l *logoWidget) TappedSecondary(event *fyne.PointEvent) {
+	menu := fyne.NewMenu("",
+		fyne.NewMenuItem("Portfolio", func() {
+			l.openURL(portfolioLink)
+		}),
+		fyne.NewMenuItem("UplyTech Website", func() {
+			l.openURL(websiteLink)
+		}),
+	)
+
+	if l.parent != nil && l.parent.window != nil {
+		pop := widget.NewPopUpMenu(menu, l.parent.window.Canvas())
+		pop.ShowAtPosition(event.AbsolutePosition)
+	}
+}
+
+func (l *logoWidget) openURL(target string) {
+	if l.parent == nil || l.parent.app == nil {
+		return
+	}
+
+	parsed, err := url.Parse(target)
+	if err != nil {
+		fmt.Println(utils.Red, "Ungültige URL:", target, utils.Reset)
+		return
+	}
+
+	if err := l.parent.app.OpenURL(parsed); err != nil {
+		fmt.Println(utils.Red, "Konnte URL nicht öffnen:", target, utils.Reset)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the web-based console with a desktop window that captures stdout/stderr and routes command execution through the existing dispatcher
- present the console in a fixed-size window with only minimise/close controls and include a clear action within the UI
- add a right-click menu on the window logo linking to the portfolio and UplyTech website

## Testing
- go build ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68f7b700f248832caaebf128532d6d5c