### PR TITLE
Fix stubbed Fyne Run to block until windows close

### DIFF
--- a/third_party/fyne/app/app.go
+++ b/third_party/fyne/app/app.go
@@ -15,20 +15,73 @@ func New() fyne.App {
 }
 
 type stubApp struct {
-	mu      sync.Mutex
-	windows []*stubWindow
+	mu        sync.Mutex
+	windows   map[*stubWindow]struct{}
+	runOnce   sync.Once
+	runCh     chan struct{}
+	runClosed bool
 }
 
 func (a *stubApp) NewWindow(title string) fyne.Window {
 	win := &stubWindow{title: title, app: a}
+
 	a.mu.Lock()
-	a.windows = append(a.windows, win)
+	if a.windows == nil {
+		a.windows = make(map[*stubWindow]struct{})
+	}
+	a.windows[win] = struct{}{}
 	a.mu.Unlock()
+
+	a.runChannel()
+
 	return win
 }
 
 func (a *stubApp) Run() {
-	// No event loop in the stub implementation.
+	ch := a.runChannel()
+
+	shouldClose := false
+	a.mu.Lock()
+	if len(a.windows) == 0 && !a.runClosed {
+		a.runClosed = true
+		shouldClose = true
+	}
+	a.mu.Unlock()
+
+	if shouldClose {
+		close(ch)
+	}
+
+	<-ch
+}
+
+func (a *stubApp) runChannel() chan struct{} {
+	a.runOnce.Do(func() {
+		a.runCh = make(chan struct{})
+	})
+	return a.runCh
+}
+
+func (a *stubApp) windowClosed(win *stubWindow) {
+	var ch chan struct{}
+	shouldClose := false
+
+	a.mu.Lock()
+	if a.windows != nil {
+		if _, ok := a.windows[win]; ok {
+			delete(a.windows, win)
+			if len(a.windows) == 0 && !a.runClosed && a.runCh != nil {
+				a.runClosed = true
+				ch = a.runCh
+				shouldClose = true
+			}
+		}
+	}
+	a.mu.Unlock()
+
+	if shouldClose {
+		close(ch)
+	}
 }
 
 func (a *stubApp) QueueUpdate(fn func()) {
@@ -51,6 +104,9 @@ type stubWindow struct {
 	size           fyne.Size
 	content        fyne.CanvasObject
 	closeIntercept func()
+
+	mu     sync.Mutex
+	closed bool
 }
 
 func (w *stubWindow) SetMaster() {}
@@ -70,8 +126,22 @@ func (w *stubWindow) SetCloseIntercept(fn func()) {
 func (w *stubWindow) Show() {}
 
 func (w *stubWindow) Close() {
-	if w.closeIntercept != nil {
-		w.closeIntercept()
+	w.mu.Lock()
+	if w.closed {
+		w.mu.Unlock()
+		return
+	}
+	w.closed = true
+	intercept := w.closeIntercept
+	w.closeIntercept = nil
+	w.mu.Unlock()
+
+	if intercept != nil {
+		intercept()
+	}
+
+	if w.app != nil {
+		w.app.windowClosed(w)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make the stubbed fyne.App implementation track windows and block Run until the last window closes
- ensure stubbed windows close idempotently and notify the app so builds behave like the real GUI loop

## Testing
- go build ./...
- go build -tags desktop ./...


------
https://chatgpt.com/codex/tasks/task_e_68f7d743b130832cab2b911a13d6e4c2