### PR TITLE
Fix htop theme embed usage

### DIFF
--- a/src/cmd/htop_theme.go
+++ b/src/cmd/htop_theme.go
@@ -1,6 +1,6 @@
 package cmd
 
-import "embed"
+import _ "embed"
 
 //go:embed assets/htoprc
 var htopTheme []byte


### PR DESCRIPTION
## Summary
- fix the htop theme file embedding to avoid unused import errors when cross-compiling

## Testing
- GOOS=windows GOARCH=amd64 go build ./...


------
https://chatgpt.com/codex/tasks/task_e_68f8fa4cc14c832c9401da777a73354b